### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Maven:
 <dependency>
   <groupId>io.eventuate.client.java</groupId>
   <artifactId>eventuate-client-java-http-stomp-spring</artifactId>
-  <version>0.1/version>
+  <version>0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The eventuate client maven dependency was not well formed, it lacked a < in the closing version tag
